### PR TITLE
Display collection type of claims and show items on Related section

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,6 +6,7 @@ android {
     flavorDimensions "default"
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -60,6 +61,7 @@ configurations {
 
 dependencies {
 //    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
 
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'

--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -2693,11 +2693,11 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         showNotifications();
     }
 
-    private void showBottomNavigation() {
+    public void showBottomNavigation() {
         findViewById(R.id.bottom_navigation).setVisibility(View.VISIBLE);
     }
 
-    private void hideBottomNavigation() {
+    public void hideBottomNavigation() {
         findViewById(R.id.bottom_navigation).setVisibility(View.GONE);
     }
 

--- a/app/src/main/java/com/odysee/app/adapter/ClaimListAdapter.java
+++ b/app/src/main/java/com/odysee/app/adapter/ClaimListAdapter.java
@@ -1,5 +1,6 @@
 package com.odysee.app.adapter;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.text.format.DateUtils;
 import android.view.LayoutInflater;
@@ -316,6 +317,7 @@ public class ClaimListAdapter extends RecyclerView.Adapter<ClaimListAdapter.View
         return new ClaimListAdapter.ViewHolder(v);
     }
 
+    @SuppressLint("UseCompatLoadingForDrawables")
     @Override
     public void onBindViewHolder(ClaimListAdapter.ViewHolder vh, int position) {
         int type = getItemViewType(position);
@@ -437,8 +439,7 @@ public class ClaimListAdapter extends RecyclerView.Adapter<ClaimListAdapter.View
             vh.titleView.setText("Nothing here. Publish something!");
             vh.alphaView.setText(item.getName().substring(0, Math.min(5, item.getName().length() - 1)));
         } else {
-            if (Claim.TYPE_STREAM.equalsIgnoreCase(item.getValueType())) {
-                long duration = item.getDuration();
+            if (Claim.TYPE_STREAM.equalsIgnoreCase(item.getValueType()) || Claim.TYPE_COLLECTION.equalsIgnoreCase(item.getValueType())) {
                 if (!Helper.isNullOrEmpty(thumbnailUrl)) {
                     Glide.with(context.getApplicationContext()).
                             asBitmap().
@@ -457,13 +458,21 @@ public class ClaimListAdapter extends RecyclerView.Adapter<ClaimListAdapter.View
                 vh.publisherView.setText(signingChannel != null ? signingChannel.getName() : context.getString(R.string.anonymous));
                 vh.publishTimeView.setText(DateUtils.getRelativeTimeSpanString(
                         publishTime, System.currentTimeMillis(), 0, DateUtils.FORMAT_ABBREV_RELATIVE));
-                vh.durationView.setVisibility((duration > 0 || item.isLive()) ? View.VISIBLE : View.GONE);
+                long duration = item.getDuration();
+                vh.durationView.setVisibility((duration > 0 || item.isLive() || Claim.TYPE_COLLECTION.equalsIgnoreCase(item.getValueType())) ? View.VISIBLE : View.GONE);
                 if (item.isLive()) {
                     vh.durationView.setBackgroundColor(ContextCompat.getColor(context, R.color.colorAccent));
                     vh.durationView.setText(context.getResources().getString(R.string.live).toUpperCase());
                 } else {
                     vh.durationView.setBackgroundColor(ContextCompat.getColor(context, android.R.color.black));
-                    vh.durationView.setText(Helper.formatDuration(duration));
+                    if (!Claim.TYPE_COLLECTION.equalsIgnoreCase(item.getValueType())) {
+                        vh.durationView.setText(Helper.formatDuration(duration));
+                        vh.durationView.setCompoundDrawablesRelativeWithIntrinsicBounds(0, 0, 0, 0);
+                    } else {
+                        vh.durationView.setText(String.valueOf(item.getClaimIds().size()));
+                        vh.durationView.setCompoundDrawablesRelativeWithIntrinsicBounds(R.drawable.ic_list_icon, 0, 0, 0);
+                        vh.durationView.setCompoundDrawablePadding(8);
+                    }
                 }
 
                 LbryFile claimFile = item.getFile();

--- a/app/src/main/java/com/odysee/app/callable/Search.java
+++ b/app/src/main/java/com/odysee/app/callable/Search.java
@@ -1,0 +1,21 @@
+package com.odysee.app.callable;
+
+import com.odysee.app.model.Claim;
+import com.odysee.app.utils.Lbry;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+public class Search implements Callable<List<Claim>> {
+    private final Map<String, Object> options;
+
+    public Search(Map<String, Object> options) {
+        this.options = options;
+    }
+
+    @Override
+    public List<Claim> call() throws Exception {
+        return Lbry.claimSearch(options, Lbry.API_CONNECTION_STRING);
+    }
+}

--- a/app/src/main/java/com/odysee/app/ui/channel/ChannelContentFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/channel/ChannelContentFragment.java
@@ -219,8 +219,13 @@ public class ChannelContentFragment extends Fragment implements DownloadActionLi
             canShowMatureContent = sp.getBoolean(MainActivity.PREFERENCE_KEY_SHOW_MATURE_CONTENT, false);
         }
 
+        // Exclude Collections from requested claims
+        List<String> claimTypes = new ArrayList<>(2);
+        claimTypes.add(Claim.TYPE_STREAM);
+        claimTypes.add(Claim.TYPE_REPOST);
+
         return Lbry.buildClaimSearchOptions(
-                null,
+                claimTypes,
                 null,
                 canShowMatureContent ? null : new ArrayList<>(Predefined.MATURE_TAGS),
                 !Helper.isNullOrEmpty(channelId) ? Arrays.asList(channelId) : null,

--- a/app/src/main/java/com/odysee/app/ui/channel/ChannelFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/channel/ChannelFragment.java
@@ -532,7 +532,7 @@ public class ChannelFragment extends BaseFragment implements FetchChannelsListen
                     new Handler().postDelayed(new Runnable() {
                         @Override
                         public void run() {
-                            tabPager.setCurrentItem(2);
+                            tabPager.setCurrentItem(3);
                         }
                     }, 500);
                 }
@@ -542,8 +542,9 @@ public class ChannelFragment extends BaseFragment implements FetchChannelsListen
                 public void onConfigureTab(@NonNull TabLayout.Tab tab, int position) {
                     switch (position) {
                         case 0: tab.setText(R.string.content); break;
-                        case 1: tab.setText(R.string.about); break;
-                        case 2: tab.setText(R.string.comments); break;
+                        case 1: tab.setText(R.string.playlists); break;
+                        case 2: tab.setText(R.string.about); break;
+                        case 3: tab.setText(R.string.comments); break;
                     }
                 }
             }).attach();
@@ -604,6 +605,13 @@ public class ChannelFragment extends BaseFragment implements FetchChannelsListen
                     return contentFragment;
 
                 case 1:
+                    ChannelPlaylistsFragment playlistsFragment = ChannelPlaylistsFragment.class.newInstance();
+                    if (channelClaim != null) {
+                        playlistsFragment.setChannelId(channelClaim.getClaimId());
+                    }
+                    return playlistsFragment;
+
+                case 2:
                     ChannelAboutFragment aboutFragment = ChannelAboutFragment.class.newInstance();
                     try {
                         Claim.ChannelMetadata metadata = (Claim.ChannelMetadata) channelClaim.getValue();
@@ -617,7 +625,7 @@ public class ChannelFragment extends BaseFragment implements FetchChannelsListen
                     }
                     return aboutFragment;
 
-                case 2:
+                case 3:
                     ChannelCommentsFragment commentsFragment = ChannelCommentsFragment.class.newInstance();
                     if (channelClaim != null) {
                         commentsFragment.setClaim(channelClaim);
@@ -638,7 +646,7 @@ public class ChannelFragment extends BaseFragment implements FetchChannelsListen
 
         @Override
         public int getItemCount() {
-            return 3;
+            return 4;
         }
     }
 }

--- a/app/src/main/java/com/odysee/app/ui/channel/ChannelPlaylistsFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/channel/ChannelPlaylistsFragment.java
@@ -1,0 +1,192 @@
+package com.odysee.app.ui.channel;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+import androidx.preference.PreferenceManager;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.odysee.app.MainActivity;
+import com.odysee.app.R;
+import com.odysee.app.adapter.ClaimListAdapter;
+import com.odysee.app.model.Claim;
+import com.odysee.app.tasks.claim.ClaimSearchResultHandler;
+import com.odysee.app.tasks.claim.ClaimSearchTask;
+import com.odysee.app.utils.Helper;
+import com.odysee.app.utils.Lbry;
+import com.odysee.app.utils.Predefined;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import lombok.Setter;
+
+public class ChannelPlaylistsFragment extends Fragment implements SharedPreferences.OnSharedPreferenceChangeListener {
+    @Setter
+    private String channelId;
+    private RecyclerView playlistsList;
+    private View contentLoading;
+    private View bigPlaylistsLoading;
+    private View noPlaylistsView;
+    private ClaimListAdapter playlistsListAdapter;
+    private boolean playlistsClaimSearchLoading;
+    private boolean playlistsHasReachedEnd;
+    private int currentClaimSearchPage;
+
+    public View onCreateView(@NonNull LayoutInflater inflater,
+                             ViewGroup container, Bundle savedInstanceState) {
+        View root = inflater.inflate(R.layout.fragment_channel_playlists, container, false);
+
+        bigPlaylistsLoading = root.findViewById(R.id.channel_playlists_list_progress);
+        contentLoading = root.findViewById(R.id.channel_content_load_progress);
+        noPlaylistsView = root.findViewById(R.id.channel_playlists_no_claim_search_lists);
+
+        playlistsList = root.findViewById(R.id.channel_playlists_list);
+        LinearLayoutManager llm = new LinearLayoutManager(getContext());
+        playlistsList.setLayoutManager(llm);
+        playlistsList.addOnScrollListener(new RecyclerView.OnScrollListener() {
+            @Override
+            public void onScrolled(@NonNull RecyclerView recyclerView, int dx, int dy) {
+                if (playlistsClaimSearchLoading) {
+                    return;
+                }
+
+                LinearLayoutManager lm = (LinearLayoutManager) recyclerView.getLayoutManager();
+                if (lm != null) {
+                    int visibleItemCount = lm.getChildCount();
+                    int totalItemCount = lm.getItemCount();
+                    int pastVisibleItems = lm.findFirstVisibleItemPosition();
+                    if (pastVisibleItems + visibleItemCount >= totalItemCount) {
+                        if (!playlistsHasReachedEnd) {
+                            // load more
+                            currentClaimSearchPage++;
+                            fetchClaimSearchPlaylists();
+                        }
+                    }
+                }
+            }
+        });
+
+        return root;
+    }
+
+    public void onResume() {
+        super.onResume();
+        Context context = getContext();
+        if (context != null) {
+            PreferenceManager.getDefaultSharedPreferences(context).registerOnSharedPreferenceChangeListener(this);
+        }
+        fetchClaimSearchPlaylists();
+    }
+
+    public void onPause() {
+        Context context = getContext();
+        if (context != null) {
+            PreferenceManager.getDefaultSharedPreferences(context).registerOnSharedPreferenceChangeListener(this);
+        }
+        super.onPause();
+    }
+
+    private Map<String, Object> buildPlaylistsOptions() {
+        Context context = getContext();
+        boolean canShowMatureContent = false;
+        if (context != null) {
+            SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(context);
+            canShowMatureContent = sp.getBoolean(MainActivity.PREFERENCE_KEY_SHOW_MATURE_CONTENT, false);
+        }
+
+        return Lbry.buildClaimSearchOptions(
+                Collections.singletonList(Claim.TYPE_COLLECTION),
+                null,
+                canShowMatureContent ? null : new ArrayList<>(Predefined.MATURE_TAGS),
+                !Helper.isNullOrEmpty(channelId) ? Collections.singletonList(channelId) : null,
+                null,
+                null,
+                null,
+                0,
+                0,
+                currentClaimSearchPage == 0 ? 1 : currentClaimSearchPage,
+                Helper.CONTENT_PAGE_SIZE);
+    }
+
+    private View getLoadingView() {
+        return (playlistsListAdapter == null || playlistsListAdapter.getItemCount() == 0) ? bigPlaylistsLoading : contentLoading;
+    }
+
+    private void fetchClaimSearchPlaylists() {
+        fetchClaimSearchPlaylists(false);
+    }
+
+    private void fetchClaimSearchPlaylists(boolean reset) {
+        if (reset && playlistsListAdapter != null) {
+            playlistsListAdapter.clearItems();
+            currentClaimSearchPage = 1;
+        }
+
+        playlistsClaimSearchLoading = true;
+        Helper.setViewVisibility(noPlaylistsView, View.GONE);
+        Map<String, Object> claimSearchOptions = buildPlaylistsOptions();
+        // channel claim
+        ClaimSearchTask playlistsClaimSearchTask = new ClaimSearchTask(claimSearchOptions, Lbry.API_CONNECTION_STRING, getLoadingView(), new ClaimSearchResultHandler() {
+            @Override
+            public void onSuccess(List<Claim> claims, boolean hasReachedEnd) {
+                claims = Helper.filterClaimsByOutpoint(claims);
+
+                if (playlistsListAdapter == null) {
+                    Context context = getContext();
+                    if (context != null) {
+                        playlistsListAdapter = new ClaimListAdapter(claims, context);
+                        playlistsListAdapter.setListener(new ClaimListAdapter.ClaimListItemListener() {
+                            @Override
+                            public void onClaimClicked(Claim claim) {
+                                Context context = getContext();
+                                if (context instanceof MainActivity) {
+                                    MainActivity activity = (MainActivity) context;
+                                    activity.openFileClaim(claim);
+                                }
+                            }
+                        });
+                    }
+                } else {
+                    playlistsListAdapter.addItems(claims);
+                }
+
+                if (playlistsList != null && playlistsList.getAdapter() == null) {
+                    playlistsList.setAdapter(playlistsListAdapter);
+                }
+
+                playlistsHasReachedEnd = hasReachedEnd;
+                playlistsClaimSearchLoading = false;
+                checkNoPlaylists();
+            }
+
+            @Override
+            public void onError(Exception error) {
+                playlistsClaimSearchLoading = false;
+                checkNoPlaylists();
+            }
+        });
+        playlistsClaimSearchTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+    }
+
+    private void checkNoPlaylists() {
+        boolean noPlaylists = playlistsListAdapter == null || playlistsListAdapter.getItemCount() == 0;
+        Helper.setViewVisibility(noPlaylistsView, noPlaylists ? View.VISIBLE : View.GONE);
+    }
+
+    public void onSharedPreferenceChanged(SharedPreferences sp, String key) {
+        if (key.equalsIgnoreCase(MainActivity.PREFERENCE_KEY_SHOW_MATURE_CONTENT)) {
+            fetchClaimSearchPlaylists(true);
+        }
+    }
+}

--- a/app/src/main/java/com/odysee/app/utils/Lbry.java
+++ b/app/src/main/java/com/odysee/app/utils/Lbry.java
@@ -517,8 +517,10 @@ public final class Lbry {
 
                     }
 
-                    // For now, only claims which are audio, videos or livestreaming right now can be viewed
-                    if (Claim.TYPE_REPOST.equalsIgnoreCase(claim.getValueType()) || (!claim.hasSource() && claim.isLive()) || (claim.hasSource() && (claim.getMediaType().contains("video") || claim.getMediaType().contains("audio"))))
+                    // For now, only claims which are audio, videos, playlists or livestreaming right now can be viewed
+                    if (Claim.TYPE_REPOST.equalsIgnoreCase(claim.getValueType()) || Claim.TYPE_COLLECTION.equalsIgnoreCase(claim.getValueType())
+                        || (!claim.hasSource() && claim.isLive())
+                        || (claim.hasSource() && (claim.getMediaType().contains("video") || claim.getMediaType().contains("audio"))))
                         claims.add(claim);
 
                     addClaimToCache(claim);

--- a/app/src/main/res/drawable/ic_list_icon.xml
+++ b/app/src/main/res/drawable/ic_list_icon.xml
@@ -1,0 +1,27 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <path
+      android:pathData="M15.3,4.6L8.5,1.1C8.2,1 7.8,1 7.5,1.1L0.7,4.6C0.5,4.7 0.4,5 0.5,5.2c0,0.1 0.1,0.1 0.2,0.2l6.8,3.5C7.8,9 8.2,9 8.5,8.9l6.8,-3.5c0.2,-0.1 0.3,-0.4 0.2,-0.6C15.4,4.7 15.3,4.7 15.3,4.6z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#928B9B"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M0.5,8.5l7,3.4c0.3,0.2 0.6,0.2 0.9,0l7,-3.4"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#928B9B"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M0.5,11.5l7,3.4c0.3,0.2 0.6,0.2 0.9,0l7,-3.4"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#928B9B"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/layout/fragment_channel_playlists.xml
+++ b/app/src/main/res/layout/fragment_channel_playlists.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:background="@color/pageBackground"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ProgressBar
+        android:id="@+id/channel_playlists_list_progress"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        android:visibility="gone"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:paddingTop="48dp">
+
+        <TextView
+            android:id="@+id/channel_playlists_no_claim_search_lists"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:fontFamily="@font/inter"
+            android:text="@string/no_claim_search_content"
+            style="@style/No_Content_To_Display"
+            android:visibility="gone" />
+
+        <androidx.recyclerview.widget.RecyclerView android:id="@+id/channel_playlists_list"
+            android:clipToPadding="false"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"  />
+    </LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_file_view.xml
+++ b/app/src/main/res/layout/fragment_file_view.xml
@@ -947,7 +947,7 @@
                         android:layout_marginStart="16dp"
                         android:layout_marginEnd="16dp">
 
-                        <TextView
+                        <TextView android:id="@+id/related_or_playlist"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_centerVertical="true"

--- a/app/src/main/res/layout/list_item_stream.xml
+++ b/app/src/main/res/layout/list_item_stream.xml
@@ -86,7 +86,7 @@
                 android:layout_marginBottom="4dp"
                 android:fontFamily="@font/inter"
                 android:textColor="@android:color/white"
-                android:textSize="10sp"
+                android:textSize="12sp"
                 android:textFontWeight="300"
                 android:padding="2dp"
                 android:visibility="gone" />

--- a/app/src/main/res/values-v28/styles.xml
+++ b/app/src/main/res/values-v28/styles.xml
@@ -20,6 +20,10 @@
         <item name="android:textColor">@color/lightForeground</item>
         <item name="textSize">@dimen/repost_info_textsize</item>
     </style>
+    <style name="No_Content_To_Display">
+        <item name="android:textFontWeight">300</item>
+        <item name="textSize">@dimen/no_content_to_display_textsize</item>
+    </style>
     <style name="List_item_Layout">
         <item name="android:foreground">?attr/selectableItemBackground</item>
         <item name="android:paddingBottom">8dp</item>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -11,5 +11,6 @@
     <dimen name="claim_title_text_size">14sp</dimen>
     <dimen name="claim_listitem_title_margin_end">4dp</dimen>
     <dimen name="repost_info_textsize">12sp</dimen>
+    <dimen name="no_content_to_display_textsize">14sp</dimen>
     <dimen name="comment_publisher_textsize">14sp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -136,6 +136,7 @@
     <!-- Channel view -->
     <string name="no_channel_info">There\'s nothing here yet.\nPlease check back later.</string>
     <string name="content">Content</string>
+    <string name="playlists">Playlists</string>
     <string name="website">Website</string>
     <string name="reposted">reposted</string>
     <string name="receive_all_notifications">You will receive all notifications</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -77,6 +77,9 @@
         <item name="android:textColor">@color/lightForeground</item>
         <item name="textSize">@dimen/repost_info_textsize</item>
     </style>
+    <style name="No_Content_To_Display">
+        <item name="textSize">@dimen/no_content_to_display_textsize</item>
+    </style>
     <style name="List_item_Layout">
         <item name="android:paddingBottom">8dp</item>
     </style>


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature

## What is the current behavior?
Playlists are not been shown.
## What is the new behavior?
Playlists items are shown on search results and on channel fragment. Then on single item view, playlist's items are listed instead of related content.
## Other information
This PR also fixes a problem which caused bottom navigation bar to disappear after user tapped back from Search results.

Desugaring needs to be enabled in order to use Java Stream API on any Android API Level