### PR TITLE
Expand to comment list when single comment is clicked

### DIFF
--- a/app/src/main/res/layout/fragment_file_view.xml
+++ b/app/src/main/res/layout/fragment_file_view.xml
@@ -921,6 +921,9 @@
                         android:textSize="14sp"
                         android:visibility="gone" />
 
+                    <include android:id="@+id/contracted_comment"
+                        layout="@layout/list_item_comment" />
+
                     <androidx.recyclerview.widget.RecyclerView
                         android:id="@+id/file_view_comments_list"
                         android:layout_width="match_parent"


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Feature

## Fixes

Issue Number: #1 

## What is the current behavior?
Comment list can only be expanded by clicking the Expand button
## What is the new behavior?
Now it will also expand when clicking on the single content when list is not expanded.
## Other information
This PR is also refactoring some code to get the color for the reaction buttons
