### PR TITLE
Don't reset wallet detail items and adapter on start

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/wallet/WalletFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/wallet/WalletFragment.java
@@ -285,11 +285,6 @@ public class WalletFragment extends BaseFragment implements WalletBalanceListene
         itemDecoration.setDrawable(ContextCompat.getDrawable(context, R.drawable.thin_divider));
         recentTransactionsList.addItemDecoration(itemDecoration);
 
-        detailRows = new ArrayList<>(3);
-
-        detailAdapter = new WalletDetailAdapter(context, detailRows);
-        detailListView.setAdapter(detailAdapter);
-
         buttonViewMore.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: #1 

## What is the current behavior?
Wallet detail is not shown when clicking the "View more" button
## What is the new behavior?
Now it is shown