### PR TITLE
Hide notifications when opening Search or Publish UI

### DIFF
--- a/app/src/main/java/com/odysee/app/MainActivity.java
+++ b/app/src/main/java/com/odysee/app/MainActivity.java
@@ -593,6 +593,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                 // Hide bottom navigation
                 // Hide main bar
                 // Show PublishFragment.class
+                // hideNotifications(); // Avoid showing Notifications fragment when clicking Publish when Notification panel is opened
 //                fragmentManager.beginTransaction().replace(R.id.main_activity_other_fragment, new PublishFragment(), "PUBLISH").addToBackStack("publish_claim").commit();
 //                findViewById(R.id.main_activity_other_fragment).setVisibility(View.VISIBLE);
 //                findViewById(R.id.fragment_container_main_activity).setVisibility(View.GONE);
@@ -605,6 +606,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
             @Override
             public void onClick(View view) {
                 // Enter Search Mode
+                hideNotifications();
                 hideBottomNavigation();
                 switchToolbarForSearch(true);
                 findViewById(R.id.fragment_container_main_activity).setVisibility(View.GONE);


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: #1 

## What is the current behavior?
Notifications fragment is not closed when user clicks Search when Notifications are being shown
## What is the new behavior?
Notifications fragment is closed