### PR TITLE
Don't show blank single comment while loading comments

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -300,7 +300,7 @@ public class FileViewFragment extends BaseFragment implements
         tipButton = root.findViewById(R.id.file_view_action_tip);
 
         expandButton = root.findViewById(R.id.expand_commentarea_button);
-        singleCommentRoot = root.findViewById(R.id.contracted_comment);
+        singleCommentRoot = root.findViewById(R.id.collapsed_comment);
 
         containerCommentForm = root.findViewById(R.id.container_comment_form);
         containerReplyToComment = root.findViewById(R.id.comment_form_reply_to_container);
@@ -2800,7 +2800,7 @@ public class FileViewFragment extends BaseFragment implements
                     commentListAdapter == null || commentListAdapter.getItemCount() == 0 ? View.VISIBLE : View.GONE);
             Helper.setViewVisibility(root.findViewById(R.id.expand_commentarea_button),
                     commentListAdapter == null || commentListAdapter.getItemCount() == 0 ? View.GONE : View.VISIBLE);
-            Helper.setViewVisibility(root.findViewById(R.id.contracted_comment),
+            Helper.setViewVisibility(root.findViewById(R.id.collapsed_comment),
                     commentListAdapter == null || commentListAdapter.getItemCount() == 0 ? View.GONE : View.VISIBLE);
 
             if (commentListAdapter == null)
@@ -3557,7 +3557,7 @@ public class FileViewFragment extends BaseFragment implements
         Context context = getContext();
 
         if (expanded) {
-            root.findViewById(R.id.contracted_comment).setVisibility(View.GONE);
+            root.findViewById(R.id.collapsed_comment).setVisibility(View.GONE);
             Helper.setViewVisibility(containerCommentForm, View.VISIBLE);
             Helper.setViewVisibility(relatedContentArea, View.GONE);
             Helper.setViewVisibility(actionsArea, View.GONE);
@@ -3566,7 +3566,7 @@ public class FileViewFragment extends BaseFragment implements
                 expandButton.setImageDrawable(getResources().getDrawable(R.drawable.ic_close, context.getTheme()));
         } else {
             Helper.setViewVisibility(containerCommentForm, View.GONE);
-            root.findViewById(R.id.contracted_comment).setVisibility(View.VISIBLE);
+            root.findViewById(R.id.collapsed_comment).setVisibility(View.VISIBLE);
             Helper.setViewVisibility(relatedContentArea, View.VISIBLE);
             Helper.setViewVisibility(actionsArea, View.VISIBLE);
             Helper.setViewVisibility(publisherArea, View.VISIBLE);

--- a/app/src/main/res/layout/fragment_file_view.xml
+++ b/app/src/main/res/layout/fragment_file_view.xml
@@ -921,8 +921,9 @@
                         android:textSize="14sp"
                         android:visibility="gone" />
 
-                    <include android:id="@+id/contracted_comment"
-                        layout="@layout/list_item_comment" />
+                    <include android:id="@+id/collapsed_comment"
+                        layout="@layout/list_item_comment"
+                        android:visibility="gone"/>
 
                     <androidx.recyclerview.widget.RecyclerView
                         android:id="@+id/file_view_comments_list"


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
While comments are being loaded, the layout of a single comment is displayed below the Comments section
## What is the new behavior?
Now it is only shown when a comment is available to be displayed
## Other information
The layout ID has also been renamed