### PR TITLE
Purge cancelled loading reactions tasks

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -832,8 +832,11 @@ public class FileViewFragment extends BaseFragment implements
 
         // Tasks on the scheduled executor needs to be really terminated to avoid
         // crashes if user presses back after going to a related content from here
-        if (scheduledExecutor != null && !scheduledExecutor.isShutdown()) {
+        if (scheduledExecutor != null && !scheduledExecutor.isShutdown() && futureReactions != null) {
             try {
+                // .cancel() will not remove the task, so it is needed to .purge()
+                futureReactions.cancel(true);
+                ((ScheduledThreadPoolExecutor) scheduledExecutor).purge();
                 scheduledExecutor.awaitTermination(1, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 e.printStackTrace();


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
Tasks to fetch content reaction are cancelled, but runtime will not remove them. This means that it will keep executing for the next content view.
## What is the new behavior?
Tasks are now purged before closing the single content view, so they are no longer run on the tread pool.