### PR TITLE
Re-use current content fragment for loading related content

### DIFF
--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -2599,7 +2599,12 @@ public class FileViewFragment extends BaseFragment implements
                                         if (claim.getName().startsWith("@")) {
                                             activity.openChannelClaim(claim);
                                         } else {
-                                            activity.openFileUrl(claim.getPermanentUrl()); //openClaimUrl(claim.getPermanentUrl());
+                                            Map<String, Object> params = new HashMap<>();
+                                            params.put("claimId", claim.getClaimId());
+                                            params.put("url", !Helper.isNullOrEmpty(claim.getShortUrl()) ? claim.getShortUrl() : claim.getPermanentUrl());
+
+                                            setParams(params);
+                                            checkParams();
                                         }
                                     }
                                 }


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: #1 

## What is the current behavior?
Every related content click adds a transaction to the back stack, which means the browsing history is kept
## What is the new behavior?
Related content is loaded in current fragment, which doesn't add the transaction to the back stack, not adding then to the browsing history