### PR TITLE
Show all comments on FileView and allow to collapse child replies

### DIFF
--- a/app/src/main/java/com/odysee/app/adapter/CommentItemDecoration.java
+++ b/app/src/main/java/com/odysee/app/adapter/CommentItemDecoration.java
@@ -1,0 +1,31 @@
+package com.odysee.app.adapter;
+
+import android.graphics.Rect;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.odysee.app.model.Comment;
+
+public class CommentItemDecoration extends RecyclerView.ItemDecoration {
+    final private int amount;
+
+    public CommentItemDecoration(int amount) {
+        this.amount = amount;
+    }
+
+    @Override
+    public void getItemOffsets(@NonNull Rect outRect, @NonNull View view, RecyclerView parent, @NonNull RecyclerView.State state) {
+        int position = parent.getChildAdapterPosition(view);
+        CommentListAdapter adapter =  (CommentListAdapter) parent.getAdapter();
+
+        if (adapter != null) {
+            Comment comment = adapter.items.get(position);
+
+            if (comment.getParentId()!= null) {
+                outRect.left = amount;
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/odysee/app/model/Comment.java
+++ b/app/src/main/java/com/odysee/app/model/Comment.java
@@ -15,7 +15,6 @@ public class Comment implements Comparable<Comment> {
 
     private Claim poster;
     private String claimId;
-    private List<Comment> replies;
     private long timestamp;
     private String channelId;
     private String channelName, text, id, parentId;
@@ -27,23 +26,11 @@ public class Comment implements Comparable<Comment> {
         this.text = text;
         this.id = id;
         this.parentId = parentId;
-
-        this.replies = new ArrayList<>();
     }
 
     public Comment() {
-        replies = new ArrayList<>();
-    }
 
-    public void addReply(Comment reply) {
-        if (replies == null) {
-            replies = new ArrayList<>();
-        }
-        if (!replies.contains(reply)) {
-            replies.add(reply);
-        }
     }
-
     public static Comment fromJSONObject(JSONObject jsonObject) {
         try {
             String parentId = null;

--- a/app/src/main/java/com/odysee/app/tasks/CommentListTask.java
+++ b/app/src/main/java/com/odysee/app/tasks/CommentListTask.java
@@ -1,5 +1,7 @@
 package com.odysee.app.tasks;
 
+import static java.util.stream.Collectors.groupingBy;
+
 import android.os.AsyncTask;
 import android.view.View;
 import android.widget.ProgressBar;
@@ -72,17 +74,16 @@ public class CommentListTask extends AsyncTask<Void, Void, List<Comment>> {
                 }
             }
 
-            // Sort all replies from oldest to newest at once
+            // Sort all replies from oldest to newest at once and then group them by its parent comment
             Collections.sort(children);
 
-            for (Comment child : children) {
-                for (Comment parent : comments) {
-                    if (parent.getId().equalsIgnoreCase(child.getParentId())) {
-                        parent.addReply(child);
-                        break;
-                    }
-                }
-            }
+            Map<String, List<Comment>> groupedChildrenList = children.stream().collect(groupingBy(Comment::getParentId));
+            List<Comment> finalComments = comments;
+            groupedChildrenList.forEach((key, value) -> {
+                Comment c = finalComments.stream().filter(v -> key.equalsIgnoreCase(v.getId())).findFirst().orElse(null);
+                finalComments.addAll(finalComments.indexOf(c) + 1, value);
+            });
+            comments = finalComments;
         } catch (JSONException | LbryResponseException | IOException ex) {
             error = ex;
         }

--- a/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
+++ b/app/src/main/java/com/odysee/app/ui/findcontent/FileViewFragment.java
@@ -23,6 +23,7 @@ import android.text.TextWatcher;
 import android.text.format.DateUtils;
 import android.text.method.LinkMovementMethod;
 import android.util.Base64;
+import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.ContextMenu;
 import android.view.LayoutInflater;
@@ -64,7 +65,6 @@ import com.bumptech.glide.request.RequestOptions;
 import com.github.chrisbanes.photoview.PhotoView;
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.DefaultControlDispatcher;
-import com.google.android.exoplayer2.MediaItem;
 import com.google.android.exoplayer2.ParserException;
 import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Player;
@@ -75,7 +75,6 @@ import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory;
 import com.google.android.exoplayer2.source.MediaSource;
 import com.google.android.exoplayer2.source.ProgressiveMediaSource;
 //import com.google.android.exoplayer2.ui.PlayerControlView;
-import com.google.android.exoplayer2.source.hls.HlsMediaSource;
 import com.google.android.exoplayer2.ui.PlayerView;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory;
@@ -110,6 +109,7 @@ import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -130,6 +130,7 @@ import java.util.function.Supplier;
 import com.odysee.app.MainActivity;
 import com.odysee.app.R;
 import com.odysee.app.adapter.ClaimListAdapter;
+import com.odysee.app.adapter.CommentItemDecoration;
 import com.odysee.app.adapter.CommentListAdapter;
 import com.odysee.app.adapter.InlineChannelSpinnerAdapter;
 import com.odysee.app.adapter.TagListAdapter;
@@ -192,9 +193,8 @@ import com.odysee.app.utils.Predefined;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import okhttp3.ResponseBody;
 
-import static com.odysee.app.utils.Lbry.TAG;
+import static java.util.stream.Collectors.groupingBy;
 
 public class FileViewFragment extends BaseFragment implements
         MainActivity.BackPressInterceptor,
@@ -1305,7 +1305,7 @@ public class FileViewFragment extends BaseFragment implements
         expandButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                switchCommentListVisibility(commentListAdapter.contracted);
+                switchCommentListVisibility(commentListAdapter.collapsed);
                 commentListAdapter.switchExpandedState();
             }
         });
@@ -1514,7 +1514,7 @@ public class FileViewFragment extends BaseFragment implements
         loadViewCount();
         loadReactions();
         checkIsFollowing();
-        
+
         View root = getView();
         if (root != null) {
             Context context = getContext();
@@ -2098,14 +2098,6 @@ public class FileViewFragment extends BaseFragment implements
 
         for (Comment c: comments) {
             commentIds.add(c.getId());
-
-            List <Comment> replies = c.getReplies();
-
-            if (replies.size() > 0) {
-                for (Comment r: replies) {
-                    commentIds.add(r.getId());
-                }
-            }
         }
 
         ExecutorService executor = Executors.newSingleThreadExecutor();
@@ -2704,7 +2696,35 @@ public class FileViewFragment extends BaseFragment implements
             CommentListTask task = new CommentListTask(1, 200, claim.getClaimId(), commentsLoading, new CommentListHandler() {
                 @Override
                 public void onSuccess(List<Comment> comments, boolean hasReachedEnd) {
-                    Comment singleComment = comments.get(0);
+                    Map<String, Reactions> commentReactions = loadReactions(comments);
+                    if (commentReactions != null) {
+                        for (Comment c: comments) {
+                            c.setReactions(commentReactions.get(c.getId()));
+                        }
+                    }
+
+                    List<Comment> rootComments = new ArrayList<>();
+
+                    for (Comment c : comments) {
+                        if (c.getParentId() == null) {
+                            rootComments.add(c);
+                        }
+                    }
+
+                    // Now we have level 0 comments to content
+
+                    Collections.sort(rootComments, new Comparator<Comment>() {
+                        @Override
+                        public int compare(Comment o1, Comment o2) {
+                            int o1SelfLiked = o1.getReactions().isLiked() ? 1 : 0;
+                            int o2SelfLiked = o2.getReactions().isLiked() ? 1 : 0;
+                            return (o2.getReactions().getOthersLikes() + o2SelfLiked) - (o1.getReactions().getOthersLikes() + o1SelfLiked);
+                        }
+                    });
+
+                    // Direct comments are now sorted by their amount of likes. We can now pick the
+                    // one to be displayed as the collapsed single comment.
+                    Comment singleComment = rootComments.get(0);
 
                     TextView commentText = singleCommentRoot.findViewById(R.id.comment_text);
                     ImageView thumbnailView = singleCommentRoot.findViewById(R.id.comment_thumbnail);
@@ -2724,8 +2744,12 @@ public class FileViewFragment extends BaseFragment implements
                     int bgColor = Helper.generateRandomColorForValue(singleComment.getChannelId());
                     Helper.setIconViewBackgroundColor(noThumbnailView, bgColor, false, getContext());
                     if (hasThumbnail) {
-                        Glide.with(getContext().getApplicationContext()).asBitmap().load(singleComment.getPoster().getThumbnailUrl()).
-                                apply(RequestOptions.circleCropTransform()).into(thumbnailView);
+                        Context ctx = getContext();
+                        if (ctx != null) {
+                            Context appCtx = ctx.getApplicationContext();
+                            Glide.with(appCtx).asBitmap().load(singleComment.getPoster().getThumbnailUrl()).
+                                    apply(RequestOptions.circleCropTransform()).into(thumbnailView);
+                        }
                     }
                     alphaView.setText(singleComment.getChannelName() != null ? singleComment.getChannelName().substring(1, 2).toUpperCase() : null);
                     singleCommentRoot.findViewById(R.id.comment_actions_area).setVisibility(View.GONE);
@@ -2739,12 +2763,20 @@ public class FileViewFragment extends BaseFragment implements
                         }
                     });
 
-                    Map<String, Reactions> commentReactions = new HashMap<>(); //loadReactions(comments);
-                    if (commentReactions != null) {
-                        for (Comment c: comments) {
-                            c.setReactions(commentReactions.get(c.getId()));
+                    List<Comment> parentComments = rootComments;
+//                    rootComments.clear();
+                    for (Comment c : comments) {
+                        if (!parentComments.contains(c)) {
+                            if (c.getParentId() != null) {
+                                Comment item = parentComments.stream().filter(v -> c.getParentId().equalsIgnoreCase(v.getId())).findFirst().orElse(null);
+                                if (item != null) {
+                                    parentComments.add(parentComments.indexOf(item) + 1, c);
+                                }
+                            }
                         }
                     }
+                    comments = parentComments;
+
                     Context ctx = getContext();
                     View root = getView();
                     if (ctx != null && root != null) {
@@ -2774,6 +2806,9 @@ public class FileViewFragment extends BaseFragment implements
                         });
 
                         RecyclerView commentsList = root.findViewById(R.id.file_view_comments_list);
+                        // Indent reply-type items
+                        int marginInPx = Math.round(40 * ((float) ctx.getResources().getDisplayMetrics().densityDpi / DisplayMetrics.DENSITY_DEFAULT));
+                        commentsList.addItemDecoration(new CommentItemDecoration(marginInPx));
                         commentsList.setAdapter(commentListAdapter);
                         commentListAdapter.notifyItemRangeInserted(0, comments.size());
 

--- a/app/src/main/res/layout/list_item_comment.xml
+++ b/app/src/main/res/layout/list_item_comment.xml
@@ -141,11 +141,22 @@
 
                 </LinearLayout>
             </LinearLayout>
+            <TextView android:id="@+id/textview_view_replies"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="?attr/selectableItemBackground"
+                android:text="View replies"
+                android:fontFamily="@font/inter"
+                android:textColor="@color/colorPrimary"
+                android:textSize="16sp"
+                android:clickable="true"
+                android:focusable="true"
+                android:drawableStart="@drawable/ic_expand"
+                android:drawableTint="@color/colorPrimary"
+                android:drawablePadding="4dp"
+                android:visibility="gone"
+                tools:visibility="visible"/>
         </LinearLayout>
     </RelativeLayout>
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/comment_replies"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,6 +81,9 @@
     <string name="comment_error">Your comment could not be posted at this time. Please try again later.</string>
     <string name="channel_disabled_comments">This channel has disabled comments on their page.</string>
     <string name="creator_disabled_comments">The creator of this content has disabled comments.</string>
+    <string name="comment_view_replies">View replies</string>
+    <string name="comment_hide_replies">Hide replies</string>
+
     <string name="share_lbry_content">Share LBRY content</string>
     <string name="view">View</string>
     <string name="play">Play</string>


### PR DESCRIPTION
## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature

## Fixes

Issue Number: #1

## What is the current behavior?
Not all comments are shown, picking of single comment is wrong and more resources than needed are used -nested RecyclerViews are created-
## What is the new behavior?
All comments are shown, comments are sorted by number of likes and the more liked is chosen as the one to be shown as single comment on the collapsed view. Now all comments are shown on the same RecyclerView, so no more views are created on the fly, using less momory.

Child replies are collapsed by default. A new link "View replies" is added to its parent when needed. First level of replies are indented, while other ones are not, yet.